### PR TITLE
Fix issue #7: build.gradle.kts for kotlin-dsl in AS 3.2.1

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,9 @@
 plugins {
     `kotlin-dsl`
 }
+
+repositories {
+    // The org.jetbrains.kotlin.jvm plugin requires a repository
+    // where to download the Kotlin compiler dependencies from.
+    jcenter()
+}


### PR DESCRIPTION
The kotlin-dsl plugin in Gradle requires a repository in order to download Kotlin compiler dependencies.